### PR TITLE
Fix empty string on request body

### DIFF
--- a/lib/Bitreserve/BitreserveClient.php
+++ b/lib/Bitreserve/BitreserveClient.php
@@ -323,7 +323,13 @@ class BitreserveClient
      */
     protected function createJsonBody(array $parameters)
     {
-        return (count($parameters) === 0) ? null : json_encode($parameters, empty($parameters) ? JSON_FORCE_OBJECT : 0);
+        $options = 0;
+
+        if (empty($parameters)) {
+          $options = JSON_FORCE_OBJECT;
+        }
+
+        return json_encode($parameters, $options);
     }
 
     /**

--- a/lib/Bitreserve/HttpClient/HttpClient.php
+++ b/lib/Bitreserve/HttpClient/HttpClient.php
@@ -154,7 +154,7 @@ class HttpClient implements HttpClientInterface
     /**
      * {@inheritDoc}
      */
-    public function request($path, $body = null, $httpMethod = 'GET', array $headers = array(), array $options = array())
+    public function request($path, $body, $httpMethod = 'GET', array $headers = array(), array $options = array())
     {
         if (!empty($this->options['api_version'])) {
             $path = sprintf('%s%s', $this->options['api_version'], $path);
@@ -164,13 +164,11 @@ class HttpClient implements HttpClientInterface
             $options['debug'] = $this->options['debug'];
         }
 
-        if (null !== $body) {
-            $options['body'] = $body;
-        }
-
         if (count($headers) > 0) {
             $options['headers'] = $headers;
         }
+
+        $options['body'] = $body;
 
         $request = $this->client->createRequest($httpMethod, $path, $options);
 


### PR DESCRIPTION
When guzzle receives a `null` body, it automatically assumes a `Content-Length` of `0` and sends an empty body, as expected. However, since the `application/type` require is `json`, the body should be set to `{}` instead.