### PR TITLE
Add response class for handle response objects

### DIFF
--- a/lib/Bitreserve/BitreserveClient.php
+++ b/lib/Bitreserve/BitreserveClient.php
@@ -2,10 +2,8 @@
 
 namespace Bitreserve;
 
-use Bitreserve\Exception\RuntimeException;
 use Bitreserve\HttpClient\HttpClient;
 use Bitreserve\HttpClient\HttpClientInterface;
-use Bitreserve\HttpClient\Message\ResponseMediator;
 use Bitreserve\Model\Reserve;
 use Bitreserve\Model\Ticker;
 use Bitreserve\Model\Token;
@@ -145,11 +143,11 @@ class BitreserveClient
      */
     public function getTicker()
     {
-        $data = $this->get('/ticker');
+        $response = $this->get('/ticker');
 
         return array_map(function($ticker) {
             return new Ticker($this, $ticker);
-        }, $data);
+        }, $response->getContent());
     }
 
     /**
@@ -161,11 +159,11 @@ class BitreserveClient
      */
     public function getTickerByCurrency($currency)
     {
-        $data = $this->get(sprintf('/ticker/%s', rawurlencode($currency)));
+        $response = $this->get(sprintf('/ticker/%s', rawurlencode($currency)));
 
         return array_map(function($ticker) {
             return new Ticker($this, $ticker);
-        }, $data);
+        }, $response->getContent());
     }
 
     /**
@@ -253,10 +251,12 @@ class BitreserveClient
             'X-Bitreserve-OTP' => $otp,
         ));
 
-        return $this->post('/me/tokens',
+        $response = $this->post('/me/tokens',
             array('description' => $description),
             $headers
         );
+
+        return $response->getContent();
     }
 
     /**
@@ -270,13 +270,11 @@ class BitreserveClient
      */
     public function get($path, array $parameters = array(), $requestHeaders = array())
     {
-        $response = $this->getHttpClient()->get(
+        return $this->getHttpClient()->get(
             $this->buildPath($path),
             $parameters,
             array_merge($this->getDefaultHeaders(), $requestHeaders)
         );
-
-        return ResponseMediator::getContent($response);
     }
 
     /**
@@ -290,13 +288,11 @@ class BitreserveClient
      */
     public function post($path, array $parameters = array(), $requestHeaders = array())
     {
-        $response = $this->getHttpClient()->post(
+        return $this->getHttpClient()->post(
             $this->buildPath($path),
             $this->createJsonBody($parameters),
             array_merge($this->getDefaultHeaders(), $requestHeaders)
         );
-
-        return ResponseMediator::getContent($response);
     }
 
     /**
@@ -310,13 +306,11 @@ class BitreserveClient
      */
     public function patch($path, array $parameters = array(), $requestHeaders = array())
     {
-        $response = $this->getHttpClient()->patch(
+        return $this->getHttpClient()->patch(
             $this->buildPath($path),
             $this->createJsonBody($parameters),
             array_merge($this->getDefaultHeaders(), $requestHeaders)
         );
-
-        return ResponseMediator::getContent($response);
     }
 
     /**
@@ -330,13 +324,11 @@ class BitreserveClient
      */
     public function put($path, array $parameters = array(), $requestHeaders = array())
     {
-        $response = $this->getHttpClient()->put(
+        return $this->getHttpClient()->put(
             $this->buildPath($path),
             $this->createJsonBody($parameters),
             array_merge($this->getDefaultHeaders(), $requestHeaders)
         );
-
-        return ResponseMediator::getContent($response);
     }
 
     /**
@@ -350,13 +342,11 @@ class BitreserveClient
      */
     public function delete($path, array $parameters = array(), $requestHeaders = array())
     {
-        $response = $this->getHttpClient()->delete(
+        return $this->getHttpClient()->delete(
             $this->buildPath($path),
             $this->createJsonBody($parameters),
             array_merge($this->getDefaultHeaders(), $requestHeaders)
         );
-
-        return ResponseMediator::getContent($response);
     }
 
     /**

--- a/lib/Bitreserve/HttpClient/Handler/ErrorHandler.php
+++ b/lib/Bitreserve/HttpClient/Handler/ErrorHandler.php
@@ -9,9 +9,8 @@ use Bitreserve\Exception\LogicException;
 use Bitreserve\Exception\NotFoundException;
 use Bitreserve\Exception\RuntimeException;
 use Bitreserve\Exception\TwoFactorAuthenticationRequiredException;
-use Bitreserve\HttpClient\Message\ResponseMediator;
+use Bitreserve\HttpClient\Message\Response;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Message\Response;
 
 /**
  * ErrorHandler.
@@ -66,14 +65,14 @@ class ErrorHandler
         $response = $e->getResponse();
         $statusCode = $response->getStatusCode();
 
-        $isClientError = ResponseMediator::isClientError($response);
-        $isServerError = ResponseMediator::isServerError($response);
+        $isClientError = $response->isClientError();
+        $isServerError = $response->isServerError();
 
         if ($isClientError || $isServerError) {
-            $content = ResponseMediator::getContent($response);
+            $content = $response->getContent();
 
-            $error = ResponseMediator::getError($response);
-            $description = ResponseMediator::getErrorDescription($response);
+            $error = $response->getError();
+            $description = $response->getErrorDescription();
 
             if (400 === $statusCode) {
                 throw new BadRequestException($description, $error, $statusCode, $response, $request);
@@ -98,7 +97,7 @@ class ErrorHandler
             }
 
             if (429 === $statusCode) {
-                $rateLimit = ResponseMediator::getApiRateLimit($response);
+                $rateLimit = $response->getApiRateLimit();
 
                 $description = sprintf('You have reached Bitreserve API limit. API limit is: %s. Your remaining requests will be reset at %s.', $rateLimit['limit'], date('Y-m-d H:i:s', $rateLimit['reset']));
 

--- a/lib/Bitreserve/HttpClient/HttpClient.php
+++ b/lib/Bitreserve/HttpClient/HttpClient.php
@@ -3,6 +3,7 @@
 namespace Bitreserve\HttpClient;
 
 use Bitreserve\HttpClient\Handler\ErrorHandler;
+use Bitreserve\HttpClient\Message\MessageFactory;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\ClientInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -49,7 +50,10 @@ class HttpClient implements HttpClientInterface
      */
     public function __construct(array $options = array())
     {
-        $this->options = array_merge($this->options, $options);
+        $this->options = array_merge($this->options,
+            array('message_factory' => new MessageFactory()),
+            $options
+        );
 
         $this->client = new GuzzleClient($this->options);
         $this->errorHandler = new ErrorHandler($this->options);

--- a/lib/Bitreserve/HttpClient/Message/MessageFactory.php
+++ b/lib/Bitreserve/HttpClient/Message/MessageFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Bitreserve\HttpClient\Message;
+
+use Bitreserve\HttpClient\Message\Response;
+use GuzzleHttp\Message\MessageFactory as BaseMessageFactory;
+use GuzzleHttp\Stream\Stream;
+
+/**
+ * HTTP request factory used to create Request and Response objects.
+ */
+class MessageFactory extends BaseMessageFactory
+{
+    /**
+     * Create new response.
+     *
+     * @param int $statusCode Response status code.
+     * @param array $headers Response headers.
+     * @param mixed $body Response body.
+     * @param array $options Options.
+     *
+     * @return Response
+     */
+    public function createResponse($statusCode, array $headers = array(), $body = null, array $options = array()) {
+        if (null !== $body) {
+            $body = Stream::factory($body);
+        }
+
+        return new Response($statusCode, $headers, $body, $options);
+    }
+}

--- a/lib/Bitreserve/HttpClient/Message/Response.php
+++ b/lib/Bitreserve/HttpClient/Message/Response.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Bitreserve\HttpClient\Message;
+
+use GuzzleHttp\Message\Response as BaseResponse;
+
+/**
+ * Response.
+ */
+class Response extends BaseResponse
+{
+    /**
+     * Get API rate limits from the response headers.
+     *
+     * @return array
+     */
+    public function getApiRateLimit()
+    {
+        return array(
+            'limit' => (string) $this->getHeader('X-RateLimit-Limit'),
+            'remaining' => (string) $this->getHeader('X-RateLimit-Remaining'),
+            'reset' => (string) $this->getHeader('X-RateLimit-Reset'),
+        );
+    }
+
+    /**
+     * Get the decoded body from the response.
+     *
+     * @return mixed
+     */
+    public function getContent()
+    {
+        $body = $this->getBody(true);
+        $content = json_decode($body, true);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            return $body;
+        }
+
+        return $content;
+    }
+
+    /**
+     * Get response error.
+     *
+     * @return string
+     */
+    public function getError()
+    {
+        $content = $this->getContent();
+
+        if (!is_array($content)) {
+            return 'unknown_error';
+        }
+
+        if (!empty($content['error'])) {
+            return $content['error'];
+        }
+
+        if (!empty($content['code'])) {
+            return $content['code'];
+        }
+
+        return 'unknown_error';
+    }
+
+    /**
+     * Get error description.
+     *
+     * @return string
+     */
+    public function getErrorDescription()
+    {
+        $content = $this->getContent();
+
+        if (!is_array($content)) {
+            return 'An unknown error occurred';
+        }
+
+        if (!empty($content['errors'])) {
+            return sprintf('Error List: %s', print_r($content['errors'], 1));
+        }
+
+        if (!empty($content['error_description'])) {
+            return $content['error_description'];
+        }
+
+        if (!empty($content['message'])) {
+            return $content['message'];
+        }
+
+        return 'An unknown error occurred';
+    }
+
+    /**
+     * Checks if the response is a client error.
+     *
+     * @return boolean
+     */
+    public function isClientError()
+    {
+        return $this->getStatusCode() >= 400 && $this->getStatusCode() < 500;
+    }
+
+    /**
+     * Checks if the response is a server error.
+     *
+     * @return boolean
+     */
+    public function isServerError()
+    {
+        return $this->getStatusCode() >= 500 && $this->getStatusCode() < 600;
+    }
+}

--- a/lib/Bitreserve/Model/Card.php
+++ b/lib/Bitreserve/Model/Card.php
@@ -149,9 +149,9 @@ class Card extends BaseModel implements CardInterface
      */
     public function getTransactionById($id)
     {
-        $data = $this->client->get(sprintf('/me/cards/%s/transactions', $this->id));
+        $response = $this->client->get(sprintf('/me/cards/%s/transactions', $this->id));
 
-        foreach ($data as $transaction) {
+        foreach ($response->getContent() as $transaction) {
             if ($id !== $transaction['id']) {
                 continue;
             }
@@ -167,11 +167,11 @@ class Card extends BaseModel implements CardInterface
      */
     public function getTransactions()
     {
-        $data = $this->client->get(sprintf('/me/cards/%s/transactions', $this->id));
+        $response = $this->client->get(sprintf('/me/cards/%s/transactions', $this->id));
 
         return array_map(function($transaction) {
             return new Transaction($this->client, $transaction);
-        }, $data);
+        }, $response->getContent());
     }
 
     /**
@@ -186,9 +186,9 @@ class Card extends BaseModel implements CardInterface
                 'currency' => $currency,
         ));
 
-        $data = $this->client->post(sprintf('/me/cards/%s/transactions', $this->id), $postData);
+        $response = $this->client->post(sprintf('/me/cards/%s/transactions', $this->id), $postData);
 
-        $transaction = new Transaction($this->client, $data);
+        $transaction = new Transaction($this->client, $response->getContent());
 
         return $transaction;
     }
@@ -198,9 +198,9 @@ class Card extends BaseModel implements CardInterface
      */
     public function update(array $params)
     {
-        $data = $this->client->patch(sprintf('/me/cards/%s', $this->id), $params);
+        $response = $this->client->patch(sprintf('/me/cards/%s', $this->id), $params);
 
-        $this->updateFields($data);
+        $this->updateFields($response->getContent());
 
         return $this;
     }

--- a/lib/Bitreserve/Model/Reserve.php
+++ b/lib/Bitreserve/Model/Reserve.php
@@ -24,7 +24,9 @@ class Reserve extends BaseModel implements ReserveInterface
      */
     public function getStatistics()
     {
-        return $this->client->get('/reserve/statistics');
+        $response = $this->client->get('/reserve/statistics');
+
+        return $response->getContent();
     }
 
     /**
@@ -32,9 +34,9 @@ class Reserve extends BaseModel implements ReserveInterface
      */
     public function getTransactionById($id)
     {
-        $data = $this->client->get(sprintf('/reserve/transactions/%s', $id));
+        $response = $this->client->get(sprintf('/reserve/transactions/%s', $id));
 
-        return new Transaction($this->client, $data);
+        return new Transaction($this->client, $response->getContent());
     }
 
     /**
@@ -42,10 +44,10 @@ class Reserve extends BaseModel implements ReserveInterface
      */
     public function getTransactions()
     {
-        $data = $this->client->get('/reserve/transactions');
+        $response = $this->client->get('/reserve/transactions');
 
         return array_map(function($transaction) {
             return new Transaction($this->client, $transaction);
-        }, $data);
+        }, $response->getContent());
     }
 }

--- a/lib/Bitreserve/Model/Token.php
+++ b/lib/Bitreserve/Model/Token.php
@@ -29,8 +29,8 @@ class Token extends BaseModel implements TokenInterface
      */
     public function getUser()
     {
-        $data = $this->client->get('/me');
+        $response = $this->client->get('/me');
 
-        return new User($this->client, $data);
+        return new User($this->client, $response->getContent());
     }
 }

--- a/lib/Bitreserve/Model/Transaction.php
+++ b/lib/Bitreserve/Model/Transaction.php
@@ -153,9 +153,9 @@ class Transaction extends BaseModel implements TransactionInterface
             throw new LogicException(sprintf('This transaction cannot be committed, because the current status is "%s"', $this->status));
         }
 
-        $data = $this->client->post(sprintf('/me/cards/%s/transactions/%s/commit', $this->origin['CardId'], $this->id));
+        $response = $this->client->post(sprintf('/me/cards/%s/transactions/%s/commit', $this->origin['CardId'], $this->id));
 
-        $this->updateFields($data);
+        $this->updateFields($response->getContent());
     }
 
     /**
@@ -175,8 +175,8 @@ class Transaction extends BaseModel implements TransactionInterface
             throw new LogicException(sprintf('This transaction cannot be cancelled, because the current status is %s', $this->status));
         }
 
-        $data = $this->client->post(sprintf('/me/cards/%s/transactions/%s/cancel', $this->origin['CardId'], $this->id));
+        $response = $this->client->post(sprintf('/me/cards/%s/transactions/%s/cancel', $this->origin['CardId'], $this->id));
 
-        $this->updateFields($data);
+        $this->updateFields($response->getContent());
     }
 }

--- a/lib/Bitreserve/Model/User.php
+++ b/lib/Bitreserve/Model/User.php
@@ -72,9 +72,9 @@ class User extends BaseModel implements UserInterface
      */
     public function getBalances()
     {
-        $data = $this->client->get('/me');
+        $response = $this->client->get('/me');
 
-        $this->updateFields($data);
+        $this->updateFields($response->getContent());
 
         return $this->balances['currencies'];
     }
@@ -84,9 +84,9 @@ class User extends BaseModel implements UserInterface
      */
     public function getBalanceByCurrency($currency)
     {
-        $data = $this->client->get('/me');
+        $response = $this->client->get('/me');
 
-        $this->updateFields($data);
+        $this->updateFields($response->getContent());
 
         foreach ($this->balances['currencies'] as $balanceCurrency => $balance) {
             if ($currency === $balanceCurrency) {
@@ -102,9 +102,9 @@ class User extends BaseModel implements UserInterface
      */
     public function getCardById($id)
     {
-        $data = $this->client->get(sprintf('/me/cards/%s', $id));
+        $response = $this->client->get(sprintf('/me/cards/%s', $id));
 
-        return new Card($this->client, $data);
+        return new Card($this->client, $response->getContent());
     }
 
     /**
@@ -112,11 +112,11 @@ class User extends BaseModel implements UserInterface
      */
     public function getCards()
     {
-        $data = $this->client->get('/me/cards');
+        $response = $this->client->get('/me/cards');
 
         return array_map(function($card) {
             return new Card($this->client, $card);
-        }, $data);
+        }, $response->getContent());
     }
 
     /**
@@ -124,9 +124,9 @@ class User extends BaseModel implements UserInterface
      */
     public function getCardsByCurrency($currency)
     {
-        $data = $this->client->get('/me/cards');
+        $response = $this->client->get('/me/cards');
 
-        $cards = array_reduce($data, function($cards, $card) use ($currency) {
+        $cards = array_reduce($response->getContent(), function($cards, $card) use ($currency) {
             if ($currency !== $card['currency']) {
                 return $cards;
             }
@@ -144,11 +144,11 @@ class User extends BaseModel implements UserInterface
      */
     public function getContacts()
     {
-        $data = $this->client->get('/me/contacts');
+        $response = $this->client->get('/me/contacts');
 
         return array_map(function($contact) {
             return new Contact($this->client, $contact);
-        }, $data);
+        }, $response->getContent());
     }
 
     /**
@@ -197,9 +197,9 @@ class User extends BaseModel implements UserInterface
      */
     public function getPhones()
     {
-        $data = $this->client->get('/me/phones');
+        $response = $this->client->get('/me/phones');
 
-        $this->phones = $data;
+        $this->phones = $response->getContent();
 
         return $this->phones;
     }
@@ -209,9 +209,9 @@ class User extends BaseModel implements UserInterface
      */
     public function getSettings()
     {
-        $data = $this->client->get('/me');
+        $response = $this->client->get('/me');
 
-        $this->updateFields($data);
+        $this->updateFields($response->getContent());
 
         return $this->settings;
     }
@@ -237,9 +237,9 @@ class User extends BaseModel implements UserInterface
      */
     public function getTotalBalance()
     {
-        $data = $this->client->get('/me');
+        $response = $this->client->get('/me');
 
-        $this->updateFields($data);
+        $this->updateFields($response->getContent());
 
         return array(
             'amount' => $this->balances['total'],
@@ -252,11 +252,11 @@ class User extends BaseModel implements UserInterface
      */
     public function getTransactions()
     {
-        $data = $this->client->get('/me/transactions');
+        $response = $this->client->get('/me/transactions');
 
         return array_map(function($transaction) {
             return new Transaction($this->client, $transaction);
-        }, $data);
+        }, $response->getContent());
     }
 
     /**
@@ -272,9 +272,9 @@ class User extends BaseModel implements UserInterface
      */
     public function createCard($label, $currency)
     {
-        $data = $this->client->post('/me/cards', array('label' => $label, 'currency' => $currency));
+        $response = $this->client->post('/me/cards', array('label' => $label, 'currency' => $currency));
 
-        return new Card($this->client, $data);
+        return new Card($this->client, $response->getContent());
     }
 
     /**
@@ -282,9 +282,9 @@ class User extends BaseModel implements UserInterface
      */
     public function update(array $params)
     {
-        $data = $this->client->patch('/me', $params);
+        $response = $this->client->patch('/me', $params);
 
-        $this->updateFields($data);
+        $this->updateFields($response->getContent());
 
         return $this;
     }

--- a/test/Bitreserve/Tests/Functional/BitreserveClientTest.php
+++ b/test/Bitreserve/Tests/Functional/BitreserveClientTest.php
@@ -5,6 +5,8 @@ namespace Bitreserve\Tests\Functional;
 use Bitreserve\BitreserveClient;
 
 /**
+ * BitreserveClientTest.
+ *
  * @group functional
  */
 class BitreserveClientTest extends TestCase

--- a/test/Bitreserve/Tests/Functional/TestCase.php
+++ b/test/Bitreserve/Tests/Functional/TestCase.php
@@ -7,6 +7,8 @@ use Bitreserve\Exception\ApiLimitExceedException;
 use Bitreserve\Exception\RuntimeException;
 
 /**
+ * TestCase.
+ *
  * @group functional
  */
 class TestCase extends \PHPUnit_Framework_TestCase

--- a/test/Bitreserve/Tests/HttpClient/HttpClientTest.php
+++ b/test/Bitreserve/Tests/HttpClient/HttpClientTest.php
@@ -5,13 +5,15 @@ namespace Bitreserve\Tests\HttpClient;
 use Bitreserve\BitreserveClient;
 use Bitreserve\HttpClient\HttpClient;
 use Bitreserve\HttpClient\Listener\ErrorListener;
-use Bitreserve\HttpClient\Message\ResponseMediator;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Message\Request;
 use GuzzleHttp\Message\Response;
 use Guzzle\Plugin\Mock\MockPlugin;
 use ReflectionProperty;
 
+/**
+ * HttpClientTest.
+ */
 class HttpClientTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/test/Bitreserve/Tests/HttpClient/Message/ResponseTest.php
+++ b/test/Bitreserve/Tests/HttpClient/Message/ResponseTest.php
@@ -2,9 +2,10 @@
 
 namespace Bitreserve\Tests\HttpClient\Message;
 
-use Bitreserve\HttpClient\Message\ResponseMediator;
-
-class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
+/**
+ * ResponseTest.
+ */
+class ResponseTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
@@ -18,7 +19,7 @@ class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
             ->method('getBody')
             ->will($this->returnValue(json_encode($data)));
 
-        $this->assertEquals($data, ResponseMediator::getContent($response));
+        $this->assertEquals($data, $response->getContent());
     }
 
     /**
@@ -31,7 +32,7 @@ class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
             ->method('getStatusCode')
             ->will($this->returnValue(400));
 
-        $this->assertEquals(true, ResponseMediator::isClientError($response));
+        $this->assertEquals(true, $response->isClientError());
     }
 
     /**
@@ -44,7 +45,7 @@ class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
             ->method('getStatusCode')
             ->will($this->returnValue(300));
 
-        $this->assertEquals(false, ResponseMediator::isClientError($response));
+        $this->assertEquals(false, $response->isClientError());
     }
 
     /**
@@ -57,7 +58,7 @@ class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
             ->method('getStatusCode')
             ->will($this->returnValue(500));
 
-        $this->assertEquals(true, ResponseMediator::isServerError($response));
+        $this->assertEquals(true, $response->isServerError());
     }
 
     /**
@@ -70,7 +71,7 @@ class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
             ->method('getStatusCode')
             ->will($this->returnValue(300));
 
-        $this->assertEquals(false, ResponseMediator::isServerError($response));
+        $this->assertEquals(false, $response->isServerError());
     }
 
     /**
@@ -97,11 +98,14 @@ class ResponseMediatorTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->onConsecutiveCalls($data['limit'], $data['remaining'], $data['reset']));
 
-        $this->assertEquals($data, ResponseMediator::getApiRateLimit($response));
+        $this->assertEquals($data, $response->getApiRateLimit());
     }
 
     protected function getResponseMock()
     {
-        return $this->getMockBuilder('GuzzleHttp\Message\Response')->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder('Bitreserve\HttpClient\Message\Response')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getBody', 'getStatusCode', 'getHeader'))
+            ->getMock();
     }
 }

--- a/test/Bitreserve/Tests/Model/CardTest.php
+++ b/test/Bitreserve/Tests/Model/CardTest.php
@@ -4,6 +4,9 @@ namespace Bitreserve\Tests\Model;
 
 use Bitreserve\Model\Card;
 
+/**
+ * CardTest.
+ */
 class CardTest extends TestCase
 {
     /**
@@ -160,13 +163,15 @@ class CardTest extends TestCase
             'status' => 'completed',
         ));
 
+        $response = $this->getResponseMock($data);
+
         $cardData = array('id' => 'ade869d8-7913-4f67-bb4d-72719f0a2be0');
 
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with(sprintf('/me/cards/%s/transactions', $cardData['id']))
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $card = new Card($client, $cardData);
 
@@ -194,13 +199,15 @@ class CardTest extends TestCase
             'status' => 'completed',
         ));
 
+        $response = $this->getResponseMock($data);
+
         $cardData = array('id' => 'ade869d8-7913-4f67-bb4d-72719f0a2be0');
 
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with(sprintf('/me/cards/%s/transactions', $cardData['id']))
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $card = new Card($client, $cardData);
 
@@ -229,11 +236,13 @@ class CardTest extends TestCase
             'status' => 'pending',
         );
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('post')
             ->with(sprintf('/me/cards/%s/transactions', $cardData['id']), $postData)
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $card = new Card($client, $cardData);
 

--- a/test/Bitreserve/Tests/Model/ContactTest.php
+++ b/test/Bitreserve/Tests/Model/ContactTest.php
@@ -4,6 +4,9 @@ namespace Bitreserve\Tests\Model;
 
 use Bitreserve\Model\Contact;
 
+/**
+ * ContactTest.
+ */
 class ContactTest extends TestCase
 {
     /**

--- a/test/Bitreserve/Tests/Model/ReserveTest.php
+++ b/test/Bitreserve/Tests/Model/ReserveTest.php
@@ -4,6 +4,9 @@ namespace Bitreserve\Tests\Model;
 
 use Bitreserve\Model\Reserve;
 
+/**
+ * ReserveTest.
+ */
 class ReserveTest extends TestCase
 {
     /**
@@ -26,11 +29,13 @@ class ReserveTest extends TestCase
     {
         $data = array('foo' => 'bar');
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with('/reserve/statistics')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $reserve = new Reserve($client);
 
@@ -50,11 +55,13 @@ class ReserveTest extends TestCase
             'status' => 'pending',
         ));
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with('/reserve/transactions')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $reserve = new Reserve($client);
 
@@ -74,11 +81,13 @@ class ReserveTest extends TestCase
             'status' => 'completed',
         );
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with(sprintf('/reserve/transactions/%s', $data['id']))
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $reserve = new Reserve($client);
 

--- a/test/Bitreserve/Tests/Model/TestCase.php
+++ b/test/Bitreserve/Tests/Model/TestCase.php
@@ -2,6 +2,9 @@
 
 namespace Bitreserve\Tests\Model;
 
+/**
+ * TestCase.
+ */
 abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
     abstract protected function getModelClass();
@@ -41,5 +44,22 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         );
 
         return $this->getMock('Bitreserve\HttpClient\HttpClientInterface', $methods);
+    }
+
+    protected function getResponseMock($content = null)
+    {
+        $response = $this->getMockBuilder('Bitreserve\HttpClient\Message\Response')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        if (null === $content) {
+            return $response;
+        }
+
+        $response->expects($this->any())
+            ->method('getContent')
+            ->will($this->returnValue($content));
+
+        return $response;
     }
 }

--- a/test/Bitreserve/Tests/Model/TickerTest.php
+++ b/test/Bitreserve/Tests/Model/TickerTest.php
@@ -4,6 +4,9 @@ namespace Bitreserve\Tests\Model;
 
 use Bitreserve\Model\Ticker;
 
+/**
+ * TickerTest.
+ */
 class TickerTest extends TestCase
 {
     /**

--- a/test/Bitreserve/Tests/Model/TokenTest.php
+++ b/test/Bitreserve/Tests/Model/TokenTest.php
@@ -4,8 +4,10 @@ namespace Bitreserve\Tests\Model;
 
 use Bitreserve\BitreserveClient;
 use Bitreserve\Model\Token;
-use Bitreserve\Model\User;
 
+/**
+ * TokenTest.
+ */
 class TokenTest extends TestCase
 {
     /**
@@ -32,6 +34,8 @@ class TokenTest extends TestCase
     {
         $data = array('username' => 'foobar');
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
 
         $client->expects($this->once())
@@ -41,7 +45,8 @@ class TokenTest extends TestCase
 
         $client->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($data));
+            ->with('/me')
+            ->will($this->returnValue($response));
 
         $token = new Token($client);
 

--- a/test/Bitreserve/Tests/Model/TransactionTest.php
+++ b/test/Bitreserve/Tests/Model/TransactionTest.php
@@ -4,6 +4,9 @@ namespace Bitreserve\Tests\Model;
 
 use Bitreserve\Model\Transaction;
 
+/**
+ * TransactionTest.
+ */
 class TransactionTest extends TestCase
 {
     /**
@@ -165,11 +168,13 @@ class TransactionTest extends TestCase
             'status' => 'pending',
         );
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('post')
             ->with(sprintf('/me/cards/%s/transactions/%s/commit', $data['origin']['CardId'], $data['id']))
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $transaction = new Transaction($client, $data);
         $transaction->commit();
@@ -228,11 +233,13 @@ class TransactionTest extends TestCase
             'status' => 'waiting',
         );
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('post')
             ->with(sprintf('/me/cards/%s/transactions/%s/cancel', $data['origin']['CardId'], $data['id']))
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $transaction = new Transaction($client, $data);
         $transaction->cancel();

--- a/test/Bitreserve/Tests/Model/UserTest.php
+++ b/test/Bitreserve/Tests/Model/UserTest.php
@@ -5,6 +5,9 @@ namespace Bitreserve\Tests\Model;
 use Bitreserve\BitreserveClient;
 use Bitreserve\Model\User;
 
+/**
+ * UserTest.
+ */
 class UserTest extends TestCase
 {
     /**
@@ -28,11 +31,13 @@ class UserTest extends TestCase
     {
         $data = array('firstName' => 'foo', 'lastName' => 'bar');
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('patch')
             ->with('/me',$data)
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, $data);
 
@@ -167,11 +172,13 @@ class UserTest extends TestCase
             'theme' => 'minimalistic',
         ));
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with('/me')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, $data);
 
@@ -192,11 +199,13 @@ class UserTest extends TestCase
             'internationalMasked' => '+X XXX-XXX-XX04',
         );
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with('/me/phones')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, $data);
 
@@ -216,11 +225,13 @@ class UserTest extends TestCase
             'lastName' => 'Bar',
         ));
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with('/me/contacts')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, $data);
 
@@ -245,11 +256,13 @@ class UserTest extends TestCase
             'total' => '58.05',
         ));
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with('/me')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, $data);
 
@@ -273,11 +286,13 @@ class UserTest extends TestCase
             'total' => '58.05',
         ));
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with('/me')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, $data);
 
@@ -304,11 +319,13 @@ class UserTest extends TestCase
                 'currency' => 'USD',
         ));
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with('/me')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, $data);
 
@@ -332,11 +349,13 @@ class UserTest extends TestCase
             'balance' => '499.23',
         ));
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with('/me/cards')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, array('username' => 'foobar'));
 
@@ -368,11 +387,13 @@ class UserTest extends TestCase
             'balance' => '499.23',
         ));
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with('/me/cards')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, array('username' => 'foobar'));
 
@@ -395,11 +416,13 @@ class UserTest extends TestCase
             'currency' => 'BTC',
         );
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('post')
             ->with('/me/cards')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, array('username' => 'foobar'));
 
@@ -434,11 +457,13 @@ class UserTest extends TestCase
             ))
         );
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with(sprintf('/me/cards/%s', $data['id']))
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, array('username' => 'foobar'));
 
@@ -461,11 +486,13 @@ class UserTest extends TestCase
             'status' => 'completed',
         ));
 
+        $response = $this->getResponseMock($data);
+
         $client = $this->getBitreserveClientMock();
         $client->expects($this->once())
             ->method('get')
             ->with('/me/transactions')
-            ->will($this->returnValue($data));
+            ->will($this->returnValue($response));
 
         $user = new User($client, array('username' => 'foobar'));
 


### PR DESCRIPTION
* Add a message response class to handle the response objects from the http requests.
* `BitreserveClient` http methods now returns full response.
* Models now handle directly the response objects.
* Update all tests.