### PR TITLE
Add OAuth support, improved pagination and transaction resend

### DIFF
--- a/lib/Bitreserve/Model/Transaction.php
+++ b/lib/Bitreserve/Model/Transaction.php
@@ -197,7 +197,7 @@ class Transaction extends BaseModel implements TransactionInterface
     public function cancel()
     {
         if (empty($this->origin['CardId'])) {
-            throw new LogicException('Origin CardId is missing from this transaction');
+            throw new LogicException('Origin `CardId` is missing from this transaction');
         }
 
         if ('pending' === $this->status) {
@@ -209,6 +209,24 @@ class Transaction extends BaseModel implements TransactionInterface
         }
 
         $response = $this->client->post(sprintf('/me/cards/%s/transactions/%s/cancel', $this->origin['CardId'], $this->id));
+
+        $this->updateFields($response->getContent());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resend()
+    {
+        if (empty($this->origin['CardId'])) {
+            throw new LogicException('Origin `CardId` is missing from this transaction');
+        }
+
+        if ('waiting' !== $this->status) {
+            throw new LogicException(sprintf('This transaction cannot be resent, because the current status is %s', $this->status));
+        }
+
+        $response = $this->client->post(sprintf('/me/cards/%s/transactions/%s/resend', $this->origin['CardId'], $this->id));
 
         $this->updateFields($response->getContent());
     }

--- a/lib/Bitreserve/Model/TransactionInterface.php
+++ b/lib/Bitreserve/Model/TransactionInterface.php
@@ -90,4 +90,11 @@ interface TransactionInterface
      * @return $this
      */
     public function commit();
+
+    /**
+     * Resend current transaction.
+     *
+     * @return $this
+     */
+    public function resend();
 }

--- a/lib/Bitreserve/Model/User.php
+++ b/lib/Bitreserve/Model/User.php
@@ -3,6 +3,7 @@
 namespace Bitreserve\Model;
 
 use Bitreserve\BitreserveClient;
+use Bitreserve\Exception\AuthenticationRequiredException;
 use Bitreserve\Paginator\Paginator;
 
 /**
@@ -320,5 +321,19 @@ class User extends BaseModel implements UserInterface
         $this->updateFields($response->getContent());
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function revokeToken()
+    {
+        $bearerToken = $this->client->getOption('bearer');
+
+        if (!$bearerToken) {
+            throw new AuthenticationRequiredException('Missing bearer authorization');
+        }
+
+        return $this->client->get(sprintf('/me/tokens/%s', $bearerToken));
     }
 }

--- a/lib/Bitreserve/Model/User.php
+++ b/lib/Bitreserve/Model/User.php
@@ -37,7 +37,7 @@ class User extends BaseModel implements UserInterface
      *
      * @var string
      */
-    protected $fistName;
+    protected $firstName;
 
     /**
      * Last name.
@@ -285,9 +285,9 @@ class User extends BaseModel implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function getTransactions()
+    public function getTransactions($limit = null)
     {
-        $pager = new Paginator($this->client, '/me/transactions');
+        $pager = new Paginator($this->client, '/me/transactions', array(), array(), $limit);
         $pager->setModel('Bitreserve\Model\Transaction');
 
         return $pager;

--- a/lib/Bitreserve/Model/UserInterface.php
+++ b/lib/Bitreserve/Model/UserInterface.php
@@ -126,9 +126,11 @@ interface UserInterface
     /**
      * Gets all transactions associated with the current user.
      *
+     * @param string $limit Number of transactions.
+     *
      * @return $transactions
      */
-    public function getTransactions();
+    public function getTransactions($limit = null);
 
     /**
      * Gets user username.

--- a/lib/Bitreserve/Model/UserInterface.php
+++ b/lib/Bitreserve/Model/UserInterface.php
@@ -155,4 +155,11 @@ interface UserInterface
      * @return $this
      */
     public function update(array $params);
+
+    /**
+     * Revoke current token.
+     *
+     * @return Response
+     */
+    public function revokeToken();
 }

--- a/lib/Bitreserve/Paginator/Paginator.php
+++ b/lib/Bitreserve/Paginator/Paginator.php
@@ -7,6 +7,8 @@ namespace Bitreserve\Paginator;
  */
 class Paginator
 {
+    CONST PAGINATOR_LIMIT = 50;
+
     /**
      * Bitreserve client.
      *
@@ -61,7 +63,7 @@ class Paginator
      *
      * @var int
      */
-    protected $limit = 50;
+    protected $limit;
 
     /**
      * Constructor.
@@ -70,13 +72,15 @@ class Paginator
      * @param string $path Request path.
      * @param array $parameters Request parameters.
      * @param array $headers Request headers.
+     * @param int $limit Limit.
      */
-    public function __construct($client, $path, $parameters = array(), $headers = array())
+    public function __construct($client, $path, $parameters = array(), $headers = array(), $limit = self::PAGINATOR_LIMIT)
     {
         $this->client = $client;
         $this->path = $path;
         $this->parameters = $parameters;
         $this->headers = $headers;
+        $this->limit = $limit;
     }
 
     /**

--- a/test/Bitreserve/Tests/Unit/Model/TransactionTest.php
+++ b/test/Bitreserve/Tests/Unit/Model/TransactionTest.php
@@ -300,6 +300,7 @@ class TransactionTest extends TestCase
     /**
      * @test
      * @expectedException Bitreserve\Exception\LogicException
+     * @expectedExceptionMessage Origin `CardId` is missing from this transaction
      */
     public function shouldThrowAnErrorOnCancelWhenCardIdIsNotDefined()
     {
@@ -311,6 +312,45 @@ class TransactionTest extends TestCase
 
         $transaction = new Transaction($client, $data);
         $transaction->cancel();
+    }
+
+    /**
+     * @test
+     * @expectedException Bitreserve\Exception\LogicException
+     * @expectedExceptionMessage Origin `CardId` is missing from this transaction
+     */
+    public function shouldThrowAnErrorOnResendWhenCardIdIsNotDefined()
+    {
+        $data = array(
+            'id' => 'a97bb994-6e24-4a89-b653-e0a6d0bcf634',
+        );
+
+        $client = $this->getBitreserveClientMock();
+
+        $transaction = new Transaction($client, $data);
+        $transaction->resend();
+    }
+
+    /**
+     * @test
+     * @expectedException Bitreserve\Exception\LogicException
+     * @expectedExceptionMessage This transaction cannot be resent, because the current status is pending
+     */
+    public function shouldThrowAnErrorOnResendWhenStatusIsNotWaiting()
+    {
+        $data = array(
+            'id' => 'a97bb994-6e24-4a89-b653-e0a6d0bcf634',
+            'origin' => array(
+                'CardId' => '91380a1f-c6f1-4d81-a204-8b40538c1f0d',
+            ),
+            'signature' => '1d326154e7a68c64a650af9d3233d77b8a385ce0',
+            'status' => 'pending',
+        );
+
+        $client = $this->getBitreserveClientMock();
+
+        $transaction = new Transaction($client, $data);
+        $transaction->resend();
     }
 
     protected function getModelClass()

--- a/test/Bitreserve/Tests/Unit/Model/UserTest.php
+++ b/test/Bitreserve/Tests/Unit/Model/UserTest.php
@@ -523,6 +523,58 @@ class UserTest extends TestCase
         }
     }
 
+    /**
+     * @test
+     * @expectedException Bitreserve\Exception\AuthenticationRequiredException
+     * @expectedExceptionMessage Missing bearer authorization
+     */
+    public function shouldThrowAuthenticationRequiredExceptionOnRevokeTokenWhenBearerTokenIsMissing()
+    {
+        $client = $this->getBitreserveClientMock();
+
+        $client->expects($this->once())
+            ->method('getOption')
+            ->with('bearer')
+            ->will($this->returnValue(null))
+        ;
+
+        $user = new User($client, array('username' => 'foobar'));
+
+        $user->revokeToken();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRevokeToken()
+    {
+        $bearerToken = 'foobar';
+        $expectedResult = 'qux';
+
+        $client = $this->getBitreserveClientMock();
+
+        $client->expects($this->once())
+            ->method('getOption')
+            ->with('bearer')
+            ->will($this->returnValue($bearerToken))
+        ;
+
+        $client->expects($this->once())
+            ->method('get')
+            ->with(sprintf('/me/tokens/%s', $bearerToken))
+            ->will($this->returnValue($expectedResult))
+        ;
+
+        $user = new User($client, array('username' => 'foobar'));
+
+        $this->assertEquals($expectedResult, $user->revokeToken());
+    }
+
+    /**
+     * Get currencies provider.
+     *
+     * @return array
+     */
     public function getCurrenciesProvider()
     {
         return array(
@@ -532,6 +584,11 @@ class UserTest extends TestCase
         );
     }
 
+    /**
+     * Get model class.
+     *
+     * @return string
+     */
     protected function getModelClass()
     {
         return 'Bitreserve\Model\User';


### PR DESCRIPTION
This PR adds the following functionalities:
- Bitreserve Connect authentication method;
- Support for delete token operation;
- Improves pagination by adding a default limit of 50 items;
- Resend method for transactions.

Closes #85 