### PR TITLE
Remove hhvm from travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
 
 before_script:
   - composer self-update


### PR DESCRIPTION
Removing `hhvm` because it's causing some tests to fail due to different exception messages generated by the `hhvm` system.